### PR TITLE
Fix MKR Approval log

### DIFF
--- a/frontend/imports/api/tokens.js
+++ b/frontend/imports/api/tokens.js
@@ -190,7 +190,7 @@ Tokens.watchEthApproval = function watchEthApproval() {
 };
 
 Tokens.watchMkrApproval = function watchMkrApproval() {
-  Tokens.getToken('ETH', (error, token) => {
+  Tokens.getToken('MKR', (error, token) => {
     if (!error) {
       /* eslint-disable new-cap */
       token.Approval({ owner: Session.get('address'), spender: Session.get('contractAddress') },


### PR DESCRIPTION
This was watching for ETH approval events when it should have been watching for MKR approval events.